### PR TITLE
update node_to_metadata_dict

### DIFF
--- a/llama_index/vector_stores/utils.py
+++ b/llama_index/vector_stores/utils.py
@@ -29,13 +29,13 @@ def node_to_metadata_dict(
     flat_metadata: bool = False,
 ) -> Dict[str, Any]:
     """Common logic for saving Node data into metadata dict."""
-    metadata: Dict[str, Any] = node.metadata.copy()
+    node_dict = node.dict()
+    metadata: Dict[str, Any] = node.get("metadata", {})
 
     if flat_metadata:
         _validate_is_flat_dict(metadata)
 
     # store entire node as json string - some minor text duplication
-    node_dict = node.dict()
     if remove_text:
         node_dict[text_field] = ""
 


### PR DESCRIPTION
change the serialization order inside the function to avoid using shallow copy for better compatibility and also potentially less computation.

# Description

Before last patch It directly alters the dict object associated with the node object, and it would cause problems if re-use the same node object to index again. Last patch already fixed this by using copy method of the dict. However, if the dict were nested it might still be a problem, and since the serialization of node is called anyway, it may be a repetition to use copy here. Now change the order of the serialization process so that the metadata is from the new serialized dict object.



Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
